### PR TITLE
Add proper cooldowns via command manager

### DIFF
--- a/src/commands/tag.js
+++ b/src/commands/tag.js
@@ -15,6 +15,7 @@ module.exports = class EvalCommand extends Command {
 			name: "tag",
 			description: "Reply with the answer to a common question",
 			permissions: [],
+			cooldown: 60,
 			manager_only: true,
 			moderator_only: true,
 			nda_only: true,
@@ -42,29 +43,6 @@ module.exports = class EvalCommand extends Command {
 	 * @returns {Promise<void|any>}
 	 */
 	async execute(interaction) {
-		const check = await interaction.channel.messages
-			.fetch()
-			.then(messages =>
-				messages.filter(
-					message =>
-						message.type === "APPLICATION_COMMAND" &&
-						(message.embeds[0]
-							? message.embeds[0].footer
-								? message.embeds[0].footer.text.includes("Invoked by")
-								: message.embeds[0]
-							: message.embeds[0]) &&
-						message.createdTimestamp > Date.now() - 60000
-				)
-			);
-
-		if (check.first()) {
-			interaction.reply({
-				content: "The command has already been used by someone less than 1 minute ago",
-				ephemeral: true
-			});
-			return;
-		}
-
 		const keyword = interaction.options.getString("keyword").toLowerCase();
 		const target = interaction.options.getUser("targeted_user");
 

--- a/src/modules/commands/command.js
+++ b/src/modules/commands/command.js
@@ -23,6 +23,7 @@ module.exports = class Command {
 	 * @param {boolean} [data.nda_only] - Only allow NDA Testers to use this command?
 	 * @param {boolean} [data.dev_only] - Only allow developers to use this command?
 	 * @param {string[]} [data.permissions] - Array of permissions needed for a user to use this command
+	 * @param {number} [data.cooldown] - The wait period (in seconds) to run the command again
 	 * @param {CommandOption[]} [data.options] - The command's options
 	 */
 	constructor(client, data) {
@@ -81,6 +82,12 @@ module.exports = class Command {
 		 * @type {string[]}
 		 */
 		this.permissions = data.permissions ?? [];
+
+		/**
+		 * The wait period (in seconds) to run the command again
+		 * @type {number}
+		 */
+		this.cooldown = data.cooldown;
 
 		/**
 		 * The command options

--- a/src/modules/commands/manager.js
+++ b/src/modules/commands/manager.js
@@ -246,7 +246,7 @@ module.exports = class CommandManager {
 			
 			const current_time = Date.now();
 			const time_stamps = this.cooldowns.get(command.name);
-			const cooldown_time = (command.cooldown) * 1000; // cooldowns are provided in seconds, converted to milliseconds
+			const cooldown_time = (command.cooldown) * 1000; // Cooldowns are provided in seconds, converted to milliseconds
 
 			if (time_stamps.has(interaction.channel.id)) {
 				const expiration_time = time_stamps.get(interaction.channel.id) + cooldown_time;
@@ -255,7 +255,7 @@ module.exports = class CommandManager {
 					const time_left = (expiration_time - current_time) / 1000;
 					const cooldown_time_minutes = Math.trunc(cooldown_time / 60000)
 					return interaction.reply({
-						content: `The command has already been used by someone less than ${cooldown_time_minutes} minute${cooldown_time_minutes > 1 ? `s` : ``} ago. Try again in ${time_left.toFixed(1)} seconds.`,
+						content: `The command has already been used by someone less than ${cooldown_time_minutes} minute${cooldown_time_minutes > 1 ? "s" : ""} ago. Try again in ${time_left.toFixed(1)} seconds.`,
 						ephemeral: true
 					})
 				}


### PR DESCRIPTION
This implements cooldowns by adding ``cooldown`` to a commands data specification. 

The following will happen *if* a command has a cooldown specified in the command data:
1. Setting ``command.name`` to a ``Discord.Collection`` inside of a Map if it does not exist yet. This collection is used to save previous times the command has been ran in a specific channel.
2. Then a check will occur to determine if there is an existing time stamp for the command in the channel which the command is ran, if so a message will be displayed to the user in a readable format
3. A time stamp is set for the command and a timeout is created to delete this time stamp after ``x`` seconds (which is the cooldown time)